### PR TITLE
Reimplement handlers/selectors support

### DIFF
--- a/_util.libsonnet
+++ b/_util.libsonnet
@@ -1,9 +1,18 @@
 {
-  selectorsToLabels(labelset):: {
+  selectorsToLabels(selectorArray):: {
     [s[0]]: std.strReplace(s[1], '"', '')
     for s in [
       std.split(s, '=')
-      for s in labelset
+      for s in selectorArray
     ]
   },
+
+  labelsToSelectorsString(labelsObject)::
+    std.join(
+      ',',
+      std.map(
+        function(key) "%s='%s'" % [key, labelsObject[key]],
+        std.objectFields(labelsObject)
+      )
+    ),
 }

--- a/examples/cincinnati.jsonnet
+++ b/examples/cincinnati.jsonnet
@@ -18,22 +18,19 @@ local latencyPercentileRates = slo.latencyPercentileRates({
 local volumeSLO = slo.volumeSLO({
   rules: httpRates.rateRules,
   threshold: '5000',
-  selectors: ['route="cincinnati-route-prod"', 'status_class!="5xx"'],
 });
 local latencySLO = slo.latencySLO({
   rules: latencyPercentileRates.rules,
-  rulesBuilder: latencyPercentileRates.rulesBuilder,
   threshold: '3',
 });
 local errorsSLO = slo.errorsSLO({
   rules: httpRates.errorRateRules,
-  rulesBuilder: httpRates.errorRateRulesBuilder,
   threshold: '1',
-  selectors: ['route="cincinnati-route-prod"'],
 });
-local availabilitySLO = slo.availabilitySLO(
-  errorsSLO.rulesProductBuilder, latencySLO.rulesProductBuilder
-);
+local availabilitySLO = slo.availabilitySLO({
+  latencyRules: [latencySLO.rules],
+  errorsRules: [errorsSLO.rules],
+});
 
 {
   recordingrule:

--- a/examples/service-with-handlers.jsonnet
+++ b/examples/service-with-handlers.jsonnet
@@ -1,52 +1,97 @@
 local slo = import '../valet.libsonnet';
 
 // Rules that will be reused in SLO rules
-local labels = ['service="foo"', 'component="bar"'];
+local labels = ['service="service"', 'component="component"'];
 local rates = ['5m'];
-local httpRates = slo.httpRates({
-  metric: 'haproxy_server_http_responses_total',
-  selectors: ['route="bar-prod"'],
+local httpRatesRead = slo.httpRates({
+  metric: 'http_responses_total',
+  selectors: ['handler="read"'],
   rates: rates,
   labels: labels,
-  handlers: ['job="read"', 'job="write"'],
 });
-local latencyPercentileRates = slo.latencyPercentileRates({
-  metric: 'foo_upload_seconds_bucket',
-  percentile: '95',
-  selectors: ['selector="qux"'],
-  labels: labels,
+local httpRatesWrite = slo.httpRates({
+  metric: 'http_responses_total',
+  selectors: ['handler="write"'],
   rates: rates,
-  handlers: ['job="read"', 'job="write"'],
+  labels: labels,
 });
 
-// SLOs from above rules (they will inherit the labels)
-local volumeSLO = slo.volumeSLO({
-  rules: httpRates.rateRules,
-  threshold: 100,
-  selectors: ['route="bar-prod"', 'status_class!="5xx"'],
+local latencyPercentileRatesRead = slo.latencyPercentileRates({
+  metric: 'foo_upload_seconds_bucket',
+  selectors: ['handler="read"'],
+  percentile: '95',
+  labels: labels,
+  rates: rates,
 });
-local latencySLO = slo.latencySLO({
-  rules: latencyPercentileRates.rules,
-  rulesBuilder: latencyPercentileRates.rulesBuilder,
+local latencyPercentileRatesWrite = slo.latencyPercentileRates({
+  metric: 'foo_upload_seconds_bucket',
+  selectors: ['handler="write"'],
+  percentile: '95',
+  labels: labels,
+  rates: rates,
+});
+
+local volumeSLORead = slo.volumeSLO({
+  rules: httpRatesRead.rateRules,
+  threshold: 100,
+});
+local volumeSLOWrite = slo.volumeSLO({
+  rules: httpRatesWrite.rateRules,
+  threshold: 200,
+});
+local latencySLORead = slo.latencySLO({
+  rules: latencyPercentileRatesRead.rules,
   threshold: '0.1',
 });
-local errorsSLO = slo.errorsSLO({
-  rules: httpRates.errorRateRules,
-  rulesBuilder: httpRates.errorRateRulesBuilder,
-  threshold: '0.001',
-  selectors: ['route="bar-prod"'],
+local latencySLOWrite = slo.latencySLO({
+  rules: latencyPercentileRatesWrite.rules,
+  threshold: '0.2',
 });
-local availabilitySLO = slo.availabilitySLO(
-  errorsSLO.rulesProductBuilder, latencySLO.rulesProductBuilder
-);
+local errorsSLORead = slo.errorsSLO({
+  rules: httpRatesRead.errorRateRules,
+  threshold: '0.001',
+});
+local errorsSLOWrite = slo.errorsSLO({
+  rules: httpRatesWrite.errorRateRules,
+  threshold: '0.001',
+});
+
+local availabilitySLORead = slo.availabilitySLO({
+  latencyRules: [latencySLORead.rules],
+  errorsRules: [errorsSLORead.rules],
+});
+local availabilitySLOWrite = slo.availabilitySLO({
+  latencyRules: [latencySLOWrite.rules],
+  errorsRules: [errorsSLOWrite.rules],
+});
+
+// We don't support for the moment availaility SLO as a product
+// of other availability SLOs, but this is easy to overcome
+local availabilitySLO = slo.availabilitySLO({
+  latencyRules: [latencySLORead.rules] + [latencySLOWrite.rules],
+  errorsRules: [errorsSLORead.rules] + [errorsSLOWrite.rules],
+  // let's add one label that differentiate this from the rest as
+  // handler selectors won't get in the selectors. We could also
+  // do it querying through handler="" although I guess this is
+  // clearer
+  labels: ['handler="all"'],
+});
 
 {
   recordingrule:
-    httpRates.rateRules +
-    httpRates.errorRateRules +
-    latencyPercentileRates.rules +
-    volumeSLO.rules +
-    latencySLO.rules +
-    errorsSLO.rules +
+    httpRatesRead.rateRules +
+    httpRatesWrite.rateRules +
+    httpRatesRead.errorRateRules +
+    httpRatesWrite.errorRateRules +
+    latencyPercentileRatesRead.rules +
+    latencyPercentileRatesWrite.rules +
+    volumeSLORead.rules +
+    volumeSLOWrite.rules +
+    latencySLORead.rules +
+    latencySLOWrite.rules +
+    errorsSLORead.rules +
+    errorsSLOWrite.rules +
+    availabilitySLORead.rules +
+    availabilitySLOWrite.rules +
     availabilitySLO.rules,
 }

--- a/http-rates.libsonnet
+++ b/http-rates.libsonnet
@@ -7,7 +7,6 @@ local util = import '_util.libsonnet';
       labels: [],
       rates: ['5m', '30m', '1h', '2h', '6h', '1d'],
       codeSelector: 'code',
-      handlers: [],
     } + param,
 
     local labels =
@@ -35,7 +34,7 @@ local util = import '_util.libsonnet';
       for rate in std.uniq(slo.rates)
     ],
 
-    errorRateRulesBuilder: [
+    errorRateRules: [
       {
         expr: |||
           sum(%s{%s})
@@ -53,12 +52,6 @@ local util = import '_util.libsonnet';
         handlers:: slo.handlers,
       }
       for r in self.rateRules
-    ],
-
-    errorRateRules: if std.length(slo.handlers) == 0 then self.errorRateRulesBuilder else [
-      rule { labels+: { [h[0]]: std.strReplace(h[1], '"', '') } }
-      for rule in self.errorRateRulesBuilder
-      for h in std.map(function(handler) std.split(handler, '='), slo.handlers)
     ],
   },
 }

--- a/latency.libsonnet
+++ b/latency.libsonnet
@@ -7,14 +7,13 @@ local util = import '_util.libsonnet';
       labels: [],
       rates: ['5m', '30m', '1h', '2h', '6h', '1d'],
       percentile: error 'must set percentile for latency',
-      handlers: [],
     } + param,
 
     local labels =
       util.selectorsToLabels(slo.selectors) +
       util.selectorsToLabels(slo.labels),
 
-    rulesBuilder: [
+    rules: [
       {
         expr: |||
           histogram_quantile(
@@ -33,16 +32,9 @@ local util = import '_util.libsonnet';
         ],
         labels: labels,
         rate:: rate,
-        handlers:: slo.handlers,
       }
       // remove duplicates or it will lead to duplicate rules
       for rate in std.uniq(slo.rates)
-    ],
-
-    rules: if std.length(slo.handlers) == 0 then self.rulesBuilder else [
-      rule { labels+: { [h[0]]: std.strReplace(h[1], '"', '') } }
-      for rule in self.rulesBuilder
-      for h in std.map(function(handler) std.split(handler, '='), slo.handlers)
     ],
   },
 }

--- a/slos.libsonnet
+++ b/slos.libsonnet
@@ -1,3 +1,11 @@
+// TODO: We should revisit the whole idea of passing arrays of rules
+// as arguments to build SLOs. It works fine with simple SLOs but
+// it's a nightmare when dealing with availability SLOs. It may
+// make more sense to pass rules objects with properties as
+// rates, recordFormat, percentile that can help us build the SLO
+// rules in a cleverer fashion
+local util = import '_util.libsonnet';
+
 local recordName(category, rate) =
   'component:%s:slo_ok_%s' % [category, rate];
 
@@ -5,50 +13,48 @@ local sloFromRecordingRules(category, param) =
   local slo = {
     rules: error 'must set rules for %sSLO' % category,
     threshold: error 'must set a threshold for %s SLO' % category,
-    selectors: [],
+    labels: [],
   } + param;
-
-  local exprString =
-    if std.length(slo.selectors) == 0
-    then '%s < bool(%s)'
-    else '%s{%s} < bool(%s)';
 
   [
     {
       record: recordName(category, r.rate),
-      expr: exprString %
-            if std.length(slo.selectors) == 0
-            then [r.record, slo.threshold]
-            else [r.record, std.join(',', slo.selectors), slo.threshold],
-      labels: r.labels,
+      expr: '%s{%s} < bool(%s)' % [
+        r.record,
+        util.labelsToSelectorsString(r.labels),
+        slo.threshold,
+      ],
+      labels: r.labels + util.selectorsToLabels(slo.labels),
       rate:: r.rate,
     }
     for r in slo.rules
   ];
 
-local rulesProductBuilder(category, rulesBuilder) =
-  [
-    {
-      record: recordName(category, r.rate),
-      handlers: r.handlers,
-      labels: r.labels,
-      rate: r.rate,
-    }
-    for r in rulesBuilder
-  ];
+// find all the labels that are common across the rules
+// and remove those that have different values.
+// rules is an array of arrays.
+// There is an assumption of rules coming from our own
+// rules generation and have similar structure.
+// This is not pretty.
+local commonLabels(rules) =
+  local labelNames = std.set(
+    std.flattenArrays(
+      std.map(function(outer) std.objectFields(rules[outer][0].labels),
+              std.range(0, std.length(rules) - 1))
+    )
+  );
 
-local SLOProductRules(SLORulesProductBuilder) =
-  [
-    if std.length(rule.handlers) == 0
-    then rule
-    else {
-      record: std.join(' * ', std.map(function(handler) '%s{%s}' % [
-        rule.record,
-        handler,
-      ], rule.handlers)),
-    }
-    for rule in SLORulesProductBuilder
-  ];
+  {
+    [label]: rules[0][0].labels[label]
+    for label in labelNames
+    if std.length(std.set(
+      std.map(
+        function(outer) rules[outer][0].labels[label],
+        std.range(0, std.length(rules) - 1)
+      )
+    )) == 1
+  };
+
 
 {
   volumeSLO(param):: {
@@ -57,31 +63,66 @@ local SLOProductRules(SLORulesProductBuilder) =
 
   latencySLO(param):: {
     rules: sloFromRecordingRules('latency', param),
-    rulesProductBuilder: rulesProductBuilder('latency', param.rulesBuilder),
   },
 
   errorsSLO(param):: {
     rules: sloFromRecordingRules('errors', param),
-    rulesProductBuilder: rulesProductBuilder('errors', param.rulesBuilder),
   },
 
-  availabilitySLO(errorsSLORulesProductBuilder, latencySLORulesProductBuilder):: {
-    local errorsLength = std.length(errorsSLORulesProductBuilder),
-    local latencyLength = std.length(latencySLORulesProductBuilder),
-    assert latencyLength == errorsLength :
-           error 'Non-matching length for input arrays. %d != %d' % [latencyLength, errorsLength],
+  // latencyRules and errorsRules are arrays of arrays of rules
+  // In order to avoid getting this more complicated thatn it
+  // already is, we don't support availability SLOs defined as
+  // a product of other availability SLOs. Since we only support
+  // availabilities that are product of latencies and errors, it
+  // is not a problem but we may want to revisit this in the future.
 
-    local latencySLOProductRules = SLOProductRules(latencySLORulesProductBuilder),
-    local errorsSLOProductRules = SLOProductRules(errorsSLORulesProductBuilder),
+  availabilitySLO(param):: {
+    local slo = {
+      latencyRules: error 'must set latencyRules for availabilitySLO',
+      errorsRules: error 'must set errorsRules for availabilitySLO',
+      labels: [],
+    } + param,
+
+    // TODO: Check inside arrays in rules have the same length
+
+    // We will assume that all elements of each rule arrays have
+    // the same structure and labels
+
+    // Since the record name is common for every availability slo,
+    // we need to find all the labels that are common across the rules
+    // and remove those that have different values.
+    local latencyLabels = commonLabels(slo.latencyRules),
+    local errorsLabels = commonLabels(slo.errorsRules),
+
+    // we need now to keep the labels that have the same value in both
+    // objects or that doesn't exist in one or the other
+    local sumLabels = latencyLabels + errorsLabels,
+    local labels = {
+      [key]: sumLabels[key]
+      for key in std.objectFields(sumLabels)
+      if std.objectHas(latencyLabels, key) && !std.objectHas(errorsLabels, key) ||
+         !std.objectHas(latencyLabels, key) && std.objectHas(errorsLabels, key) ||
+         latencyLabels[key] == errorsLabels[key]
+    },
+
+    local allRules = slo.latencyRules + slo.errorsRules,
 
     rules: [
       {
-        record: 'component:availability:slo_ok_%s' % errorsSLORulesProductBuilder[i].rate,
-        expr: '%s * %s' % [latencySLOProductRules[i].record, errorsSLOProductRules[i].record],
-        labels: errorsSLORulesProductBuilder[i].labels + latencySLORulesProductBuilder[i].labels,
+        record: recordName('availability', allRules[0][inner].rate),
+        labels: labels + util.selectorsToLabels(slo.labels),
+        expr: std.join(
+          ' * ',
+          std.map(
+            function(outer) '%s{%s}' % [
+              allRules[outer][inner].record,
+              util.labelsToSelectorsString(allRules[outer][inner].labels),
+            ],
+            std.range(0, std.length(allRules) - 1)
+          )
+        ),
       }
-      for i in std.range(0, latencyLength - 1)
-
+      for inner in std.range(0, std.length(allRules[0]) - 1)
     ],
   },
 }


### PR DESCRIPTION
* Handlers are now part of the selectors
* All derived (slo) rules use labels as selectors
* All derived (slo) rules inherit labels except those that have the same key but different value
* Reworked examples
* Derived rules can set additional labels. This could be interesting when we have labels with the same name and different values

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>